### PR TITLE
chore: link to published version of code refs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jstemmer/go-junit-report/v2 v2.0.0
 	github.com/kyoh86/richgo v0.3.12
 	github.com/launchdarkly/api-client-go/v13 v13.0.0
-	github.com/launchdarkly/ld-find-code-refs/v2 v2.10.1-0.20230808125804-68b13f09c742
+	github.com/launchdarkly/ld-find-code-refs/v2 v2.11.0
 )
 
 require github.com/launchdarkly/api-client-go/v7 v7.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/launchdarkly/api-client-go/v7 v7.1.1 h1:3VBkFt9xHljMw5KDlVFDUogxfH78Y
 github.com/launchdarkly/api-client-go/v7 v7.1.1/go.mod h1:GVl1inKsWoKX3yLgdqrjxWw8k4ih0HlSmdnrhi5NNDs=
 github.com/launchdarkly/json-patch v0.0.0-20180720210516-dd68d883319f h1:jfiPiz2hE/7mHv2NOS4cm07sSJCsKlbxmR7pzPhhvpU=
 github.com/launchdarkly/json-patch v0.0.0-20180720210516-dd68d883319f/go.mod h1:CHbYdMs8UjvNnS2fatlQvi4UYnBTRYGxRHc/0kQupSQ=
-github.com/launchdarkly/ld-find-code-refs/v2 v2.10.1-0.20230808125804-68b13f09c742 h1:5Q6QLoM8bNQn5TeQ7SPuJyr+vZNocbJ4uVlMl0dh0ec=
-github.com/launchdarkly/ld-find-code-refs/v2 v2.10.1-0.20230808125804-68b13f09c742/go.mod h1:eydjFkict7+Sg7jDIhg1Qgp8SzEfBSbBjABSYb097cA=
+github.com/launchdarkly/ld-find-code-refs/v2 v2.11.0 h1:6mN0vGwr6QXTy2xth83ToRwN/Uq9QW5gvbSm585fVRU=
+github.com/launchdarkly/ld-find-code-refs/v2 v2.11.0/go.mod h1:eydjFkict7+Sg7jDIhg1Qgp8SzEfBSbBjABSYb097cA=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=

--- a/vendor/github.com/launchdarkly/ld-find-code-refs/v2/internal/version/version.go
+++ b/vendor/github.com/launchdarkly/ld-find-code-refs/v2/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.10.0"
+const Version = "2.11.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,7 +85,7 @@ github.com/launchdarkly/api-client-go/v7
 # github.com/launchdarkly/json-patch v0.0.0-20180720210516-dd68d883319f
 ## explicit
 github.com/launchdarkly/json-patch
-# github.com/launchdarkly/ld-find-code-refs/v2 v2.10.1-0.20230808125804-68b13f09c742
+# github.com/launchdarkly/ld-find-code-refs/v2 v2.11.0
 ## explicit; go 1.20
 github.com/launchdarkly/ld-find-code-refs/v2/aliases
 github.com/launchdarkly/ld-find-code-refs/v2/flags


### PR DESCRIPTION
we finally have module-path v2 version of code refs that is tagged to link to!