### PR TITLE
chore: update filter syntax for get flags request

### DIFF
--- a/internal/ldclient/flags.go
+++ b/internal/ldclient/flags.go
@@ -24,7 +24,7 @@ func GetAllFlags(config *lcr.Config) ([]ldapi.FeatureFlag, error) {
 	flags = append(flags, activeFlags...)
 
 	if config.IncludeArchivedFlags {
-		params.Add("archived", "true")
+		params.Add("filter", "state:archived")
 		archivedFlags, err := getFlags(config, params)
 		if err != nil {
 			return []ldapi.FeatureFlag{}, err


### PR DESCRIPTION
removed deprecated query param `archived` in get flags request