### PR TITLE
Bumping golang version to 1.20.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ defaults:
 jobs:
   go-test:
     docker:
-      - image: cimg/go:1.20.3
+      - image: cimg/go:1.20.10
         environment:
           <<: *environment
 


### PR DESCRIPTION
Context:
https://launchdarkly.atlassian.net/browse/SEC-4640
https://nvd.nist.gov/vuln/detail/CVE-2023-44487
https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo

No security impact here, but bumping for sake of consistency 