### PR TITLE
[sc-223627] indicate changed flags that are deprecated

### DIFF
--- a/comments/comments.go
+++ b/comments/comments.go
@@ -29,6 +29,7 @@ type Comment struct {
 	Deprecated         bool
 	DeprecatedAt       time.Time
 	Added              bool
+	Removed            bool
 	Extinct            bool
 	Aliases            []string
 	ChangeType         string
@@ -49,6 +50,7 @@ func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct 
 		Archived:           flag.Archived,
 		Deprecated:         flag.Deprecated,
 		Added:              added,
+		Removed:            !added,
 		Extinct:            config.CheckExtinctions && extinct,
 		Aliases:            aliases,
 		Primary:            flag.Environments[config.LdEnvironment],

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -45,7 +45,6 @@ func isNil(a interface{}) bool {
 
 func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct bool, config *lcr.Config) (string, error) {
 	commentTemplate := Comment{
-		Flag:               flag,
 		FlagKey:            flag.Key,
 		FlagName:           flag.Name,
 		Archived:           flag.Archived,

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -84,7 +84,7 @@ func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct 
 }
 
 // Template for info cell
-// Will only show deprecated warning, if flag is not archived
+// Will only show deprecated warning if flag is not archived
 func infoCellTemplate() string {
 	return `{{- if eq .Extinct true}} :white_check_mark: all references removed` +
 		`{{- else if and .Removed .ExtinctionsEnabled}} :warning: not all references removed {{- end}} ` +

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -86,8 +86,8 @@ func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct 
 func infoCellTemplate() string {
 	return `{{- if eq .Extinct true}} :white_check_mark: all references removed` +
 		`{{- else if eq .ExtinctionsEnabled true}} :warning: not all references removed {{- end}} ` +
-		`{{- if eq .Archived true}}{{- if eq .Extinct true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}} ` +
-		`{{- else if eq .Deprecated true}}{{- if eq .Extinct true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} deprecated on {{.DeprecatedAt | date "2006-01-02"}}{{- end}}`
+		`{{- if eq .Archived true}}{{- if eq .Extinct true}}<br>{{- else if eq .ExtinctionsEnabled true}}<br>{{- end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}} ` +
+		`{{- else if eq .Deprecated true}}{{- if eq .Extinct true}}<br>{{- else if eq .ExtinctionsEnabled true}}<br>{{- end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} deprecated on {{.DeprecatedAt | date "2006-01-02"}}{{- end}}`
 }
 
 func GithubNoFlagComment() *github.IssueComment {

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -23,7 +23,12 @@ import (
 
 type Comment struct {
 	Flag               ldapi.FeatureFlag
+	FlagKey            string
+	FlagName           string
+	Archived           bool
 	ArchivedAt         time.Time
+	Deprecated         bool
+	DeprecatedAt       time.Time
 	Added              bool
 	Extinct            bool
 	Aliases            []string
@@ -41,6 +46,10 @@ func isNil(a interface{}) bool {
 func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct bool, config *lcr.Config) (string, error) {
 	commentTemplate := Comment{
 		Flag:               flag,
+		FlagKey:            flag.Key,
+		FlagName:           flag.Name,
+		Archived:           flag.Archived,
+		Deprecated:         flag.Deprecated,
 		Added:              added,
 		Extinct:            config.CheckExtinctions && extinct,
 		Aliases:            aliases,
@@ -48,28 +57,39 @@ func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct 
 		LDInstance:         config.LdInstance,
 		ExtinctionsEnabled: config.CheckExtinctions,
 	}
-	var commentBody bytes.Buffer
 	if flag.ArchivedDate != nil {
 		commentTemplate.ArchivedAt = time.UnixMilli(*flag.ArchivedDate)
 	}
+	if flag.DeprecatedDate != nil {
+		commentTemplate.DeprecatedAt = time.UnixMilli(*flag.DeprecatedDate)
+	}
+
 	// All whitespace for template is required to be there or it will not render properly nested.
-	tmplSetup := `| [{{.Flag.Name}}]({{.LDInstance}}{{.Primary.Site.Href}}) | ` +
-		"`" + `{{.Flag.Key}}` + "` |" +
+	tmplSetup := `| [{{.FlagName}}]({{.LDInstance}}{{.Primary.Site.Href}}) | ` +
+		"`" + `{{.FlagKey}}` + "` |" +
 		`{{- if ne (len .Aliases) 0}}` +
 		`{{range $i, $e := .Aliases }}` + `{{if $i}},{{end}}` + " `" + `{{$e}}` + "`" + `{{end}}` +
-		`{{- end}} | ` +
-		`{{- if eq .Extinct true}} :white_check_mark: all references removed` +
-		`{{- else if eq .ExtinctionsEnabled true}} :warning: not all references removed {{- end}} ` +
-		`{{- if eq .Flag.Archived true}}{{- if eq .Extinct true}}<br>{{- else if eq .ExtinctionsEnabled true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}}{{- end}} |`
+		`{{- end}} | ` + infoCellTemplate() + ` |`
 
 	tmpl := template.Must(template.New("comment").Funcs(template.FuncMap{"trim": strings.TrimSpace, "isNil": isNil}).Funcs(sprig.FuncMap()).Parse(tmplSetup))
-	err := tmpl.Execute(&commentBody, commentTemplate)
-	if err != nil {
+
+	var commentBody bytes.Buffer
+	if err := tmpl.Execute(&commentBody, commentTemplate); err != nil {
 		return "", err
 	}
+
 	commentStr := html.UnescapeString(commentBody.String())
 
 	return commentStr, nil
+}
+
+// Template for info cell
+// Will only show deprecated warning, if flag is not archived
+func infoCellTemplate() string {
+	return `{{- if eq .Extinct true}} :white_check_mark: all references removed` +
+		`{{- else if eq .ExtinctionsEnabled true}} :warning: not all references removed {{- end}} ` +
+		`{{- if eq .Archived true}}{{- if eq .Extinct true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}} ` +
+		`{{- else if eq .Deprecated true}}{{- if eq .Extinct true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} deprecated on {{.DeprecatedAt | date "2006-01-02"}}{{- end}}`
 }
 
 func GithubNoFlagComment() *github.IssueComment {

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -22,7 +22,6 @@ import (
 )
 
 type Comment struct {
-	Flag               ldapi.FeatureFlag
 	FlagKey            string
 	FlagName           string
 	Archived           bool

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -43,6 +43,7 @@ func isNil(a interface{}) bool {
 	return a == nil || reflect.ValueOf(a).IsNil()
 }
 
+// Test go template rendering here https://gotemplate.io/
 func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct bool, config *lcr.Config) (string, error) {
 	commentTemplate := Comment{
 		FlagKey:            flag.Key,

--- a/comments/comments.go
+++ b/comments/comments.go
@@ -85,9 +85,9 @@ func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct 
 // Will only show deprecated warning, if flag is not archived
 func infoCellTemplate() string {
 	return `{{- if eq .Extinct true}} :white_check_mark: all references removed` +
-		`{{- else if eq .ExtinctionsEnabled true}} :warning: not all references removed {{- end}} ` +
-		`{{- if eq .Archived true}}{{- if eq .Extinct true}}<br>{{- else if eq .ExtinctionsEnabled true}}<br>{{- end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}} ` +
-		`{{- else if eq .Deprecated true}}{{- if eq .Extinct true}}<br>{{- else if eq .ExtinctionsEnabled true}}<br>{{- end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} deprecated on {{.DeprecatedAt | date "2006-01-02"}}{{- end}}`
+		`{{- else if and .Removed .ExtinctionsEnabled}} :warning: not all references removed {{- end}} ` +
+		`{{- if eq .Archived true}}{{- if eq .Extinct true}}<br>{{- else if and .Removed .ExtinctionsEnabled }}<br>{{- end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}} ` +
+		`{{- else if eq .Deprecated true}}{{- if eq .Extinct true}}<br>{{- else if and .Removed .ExtinctionsEnabled }}<br>{{- end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} deprecated on {{.DeprecatedAt | date "2006-01-02"}}{{- end}}`
 }
 
 func GithubNoFlagComment() *github.IssueComment {

--- a/comments/comments_test.go
+++ b/comments/comments_test.go
@@ -180,7 +180,7 @@ func (e *testFlagEnv) NoAliases(t *testing.T) {
 	comment, err := githubFlagComment(e.Flag, []string{}, true, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [example flag](https://example.com/test) | `example-flag` | | :warning: not all references removed |"
+	expected := "| [example flag](https://example.com/test) | `example-flag` | | |"
 	assert.Equal(t, expected, comment)
 }
 
@@ -188,7 +188,7 @@ func (e *testFlagEnv) Alias(t *testing.T) {
 	comment, err := githubFlagComment(e.Flag, []string{"exampleFlag", "ExampleFlag"}, true, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [example flag](https://example.com/test) | `example-flag` | `exampleFlag`, `ExampleFlag` | :warning: not all references removed |"
+	expected := "| [example flag](https://example.com/test) | `example-flag` | `exampleFlag`, `ExampleFlag` | |"
 	assert.Equal(t, expected, comment)
 }
 
@@ -196,7 +196,7 @@ func (e *testFlagEnv) ArchivedAdded(t *testing.T) {
 	comment, err := githubFlagComment(e.ArchivedFlag, []string{}, true, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [archived flag](https://example.com/test) | `archived-flag` | | :warning: not all references removed<br> :warning: archived on 2023-08-03 |"
+	expected := "| [archived flag](https://example.com/test) | `archived-flag` | | :warning: archived on 2023-08-03 |"
 	assert.Equal(t, expected, comment)
 }
 
@@ -236,7 +236,7 @@ func (e *testFlagEnv) DeprecatedRemoved(t *testing.T) {
 	comment, err := githubFlagComment(e.DeprecatedFlag, []string{}, false, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [deprecated flag](https://example.com/test) | `deprecated-flag` | | :information_source: deprecated on 2023-08-03 |"
+	expected := "| [deprecated flag](https://example.com/test) | `deprecated-flag` | | :warning: not all references removed<br> :information_source: deprecated on 2023-08-03 |"
 	assert.Equal(t, expected, comment)
 }
 

--- a/testdata/test
+++ b/testdata/test
@@ -2,6 +2,8 @@ show-widgets
 showWidgets
 show_widgets
 oldPricingBanner
+show-widgets
 show_widgets
-oldPricingBanner
 mobile-app-promo-ios
+mobile-app-promo-ios
+beta-ui

--- a/testdata/test
+++ b/testdata/test
@@ -1,7 +1,6 @@
 show-widgets
 showWidgets
 show_widgets
-oldPricingBanner
 show-widgets
 show_widgets
 mobile-app-promo-ios


### PR DESCRIPTION
If a flag has been deprecated (but not archived) show a message.

If a archived/deprecated flag is `added or modified` we show a warning sign. if it's been removed, we show an info symbol.

![CleanShot 2024-03-20 at 12 30 59](https://github.com/launchdarkly/find-code-references-in-pull-request/assets/4053924/e6974133-e686-4367-85aa-bf6915827411)
