### PR TITLE
chore: add builder for keeping track of references found

### DIFF
--- a/comments/comments.go
+++ b/comments/comments.go
@@ -131,9 +131,7 @@ func ProcessFlags(flagsRef lflags.FlagsRef, flags []ldapi.FeatureFlag, config *l
 	// sort keys so hashing can work for checking if comment already exists
 	sort.Strings(addedKeys)
 	for _, flagKey := range addedKeys {
-		// If flag is in both added and removed then it is being modified
-		delete(flagsRef.FlagsRemoved, flagKey)
-		flagAliases := uniqueAliases(flagsRef.FlagsAdded[flagKey])
+		flagAliases := flagsRef.FlagsAdded[flagKey]
 		idx, _ := find(flags, flagKey)
 		createComment, err := githubFlagComment(flags[idx], flagAliases, true, config)
 		buildComment.CommentsAdded = append(buildComment.CommentsAdded, createComment)
@@ -147,7 +145,7 @@ func ProcessFlags(flagsRef lflags.FlagsRef, flags []ldapi.FeatureFlag, config *l
 	}
 	sort.Strings(removedKeys)
 	for _, flagKey := range removedKeys {
-		flagAliases := uniqueAliases(flagsRef.FlagsRemoved[flagKey])
+		flagAliases := flagsRef.FlagsRemoved[flagKey]
 		idx, _ := find(flags, flagKey)
 		removedComment, err := githubFlagComment(flags[idx], flagAliases, false, config)
 		buildComment.CommentsRemoved = append(buildComment.CommentsRemoved, removedComment)
@@ -182,16 +180,6 @@ func uniqueFlagKeys(a, b lflags.FlagAliasMap) []string {
 	}
 
 	return allKeys
-}
-
-func uniqueAliases(aliases lflags.AliasSet) []string {
-	flagAliases := make([]string, 0, len(aliases))
-	for alias := range aliases {
-		if len(strings.TrimSpace(alias)) > 0 {
-			flagAliases = append(flagAliases, alias)
-		}
-	}
-	return flagAliases
 }
 
 func pluralize(str string, strLength int) string {

--- a/comments/comments_test.go
+++ b/comments/comments_test.go
@@ -196,7 +196,7 @@ func (e *testFlagEnv) ArchivedRemoved(t *testing.T) {
 }
 
 func (e *testCommentBuilder) AddedOnly(t *testing.T) {
-	e.FlagsRef.FlagsAdded["example-flag"] = lflags.AliasSet{}
+	e.FlagsRef.FlagsAdded["example-flag"] = []string{}
 	e.Comments.CommentsAdded = []string{"comment1", "comment2"}
 	comment := BuildFlagComment(e.Comments, e.FlagsRef, nil)
 
@@ -205,8 +205,8 @@ func (e *testCommentBuilder) AddedOnly(t *testing.T) {
 }
 
 func (e *testCommentBuilder) RemovedOnly(t *testing.T) {
-	e.FlagsRef.FlagsRemoved["example-flag"] = lflags.AliasSet{}
-	e.FlagsRef.FlagsRemoved["sample-flag"] = lflags.AliasSet{}
+	e.FlagsRef.FlagsRemoved["example-flag"] = []string{}
+	e.FlagsRef.FlagsRemoved["sample-flag"] = []string{}
 	e.Comments.CommentsRemoved = []string{"comment1", "comment2"}
 	comment := BuildFlagComment(e.Comments, e.FlagsRef, nil)
 
@@ -215,8 +215,8 @@ func (e *testCommentBuilder) RemovedOnly(t *testing.T) {
 }
 
 func (e *testCommentBuilder) AddedAndRemoved(t *testing.T) {
-	e.FlagsRef.FlagsAdded["example-flag"] = lflags.AliasSet{}
-	e.FlagsRef.FlagsRemoved["example-flag"] = lflags.AliasSet{}
+	e.FlagsRef.FlagsAdded["example-flag"] = []string{}
+	e.FlagsRef.FlagsRemoved["example-flag"] = []string{}
 	e.Comments.CommentsAdded = []string{"comment1", "comment2"}
 	e.Comments.CommentsRemoved = []string{"comment1", "comment2"}
 	comment := BuildFlagComment(e.Comments, e.FlagsRef, nil)
@@ -228,7 +228,7 @@ func (e *testCommentBuilder) AddedAndRemoved(t *testing.T) {
 }
 
 func (e *testProcessor) Basic(t *testing.T) {
-	e.FlagsRef.FlagsAdded["example-flag"] = lflags.AliasSet{"": true}
+	e.FlagsRef.FlagsAdded["example-flag"] = []string{""}
 	processor := ProcessFlags(e.FlagsRef, e.Flags, &e.Config)
 	expected := FlagComments{
 		CommentsAdded: []string{"| [example flag](https://example.com/test) | `example-flag` | |"},
@@ -237,8 +237,8 @@ func (e *testProcessor) Basic(t *testing.T) {
 }
 
 func (e *testProcessor) Multi(t *testing.T) {
-	e.FlagsRef.FlagsAdded["example-flag"] = lflags.AliasSet{"": true}
-	e.FlagsRef.FlagsAdded["second-flag"] = lflags.AliasSet{"": true}
+	e.FlagsRef.FlagsAdded["example-flag"] = []string{""}
+	e.FlagsRef.FlagsAdded["second-flag"] = []string{""}
 	processor := ProcessFlags(e.FlagsRef, e.Flags, &e.Config)
 	expected := FlagComments{
 		CommentsAdded: []string{

--- a/comments/comments_test.go
+++ b/comments/comments_test.go
@@ -228,7 +228,7 @@ func (e *testCommentBuilder) AddedAndRemoved(t *testing.T) {
 }
 
 func (e *testProcessor) Basic(t *testing.T) {
-	e.FlagsRef.FlagsAdded["example-flag"] = []string{""}
+	e.FlagsRef.FlagsAdded["example-flag"] = []string{}
 	processor := ProcessFlags(e.FlagsRef, e.Flags, &e.Config)
 	expected := FlagComments{
 		CommentsAdded: []string{"| [example flag](https://example.com/test) | `example-flag` | |"},
@@ -237,8 +237,8 @@ func (e *testProcessor) Basic(t *testing.T) {
 }
 
 func (e *testProcessor) Multi(t *testing.T) {
-	e.FlagsRef.FlagsAdded["example-flag"] = []string{""}
-	e.FlagsRef.FlagsAdded["second-flag"] = []string{""}
+	e.FlagsRef.FlagsAdded["example-flag"] = []string{}
+	e.FlagsRef.FlagsAdded["second-flag"] = []string{}
 	processor := ProcessFlags(e.FlagsRef, e.Flags, &e.Config)
 	expected := FlagComments{
 		CommentsAdded: []string{

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -7,7 +7,7 @@ import (
 
 	lflags "github.com/launchdarkly/find-code-references-in-pull-request/flags"
 	"github.com/launchdarkly/find-code-references-in-pull-request/ignore"
-	"github.com/launchdarkly/find-code-references-in-pull-request/internal/utils"
+	diff_util "github.com/launchdarkly/find-code-references-in-pull-request/internal/util/diff_util"
 	lsearch "github.com/launchdarkly/ld-find-code-refs/v2/search"
 	"github.com/sourcegraph/go-diff/diff"
 )
@@ -54,8 +54,8 @@ func CheckDiff(parsedDiff *diff.FileDiff, workspace string) *DiffPaths {
 func ProcessDiffs(matcher lsearch.Matcher, hunk *diff.Hunk, builder *lflags.ReferenceBuilder) {
 	diffLines := strings.Split(string(hunk.Body), "\n")
 	for _, line := range diffLines {
-		op := utils.LineOperation(line)
-		if op == utils.OperationEqual {
+		op := diff_util.LineOperation(line)
+		if op == diff_util.OperationEqual {
 			continue
 		}
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -99,6 +99,8 @@ func (o Operation) String() string {
 		return "+"
 	case Delete:
 		return "-"
+	case Equal:
+		return ""
 	}
 
 	return ""

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -83,10 +83,10 @@ const (
 )
 
 func operation(row string) Operation {
-	if strings.HasPrefix(row, "+") {
+	if strings.HasPrefix(row, Add.String()) {
 		return Add
 	}
-	if strings.HasPrefix(row, "-") {
+	if strings.HasPrefix(row, Delete.String()) {
 		return Delete
 	}
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -61,7 +61,7 @@ func ProcessDiffs(matcher lsearch.Matcher, hunk *diff.Hunk, builder *lflags.Refe
 		// only one for now
 		elementMatcher := matcher.Elements[0]
 		for _, flagKey := range elementMatcher.FindMatches(line) {
-			aliasMatches := matcher.FindAliases(line, flagKey)
+			aliasMatches := elementMatcher.FindAliases(line, flagKey)
 			builder.AddReference(flagKey, op.String(), aliasMatches)
 		}
 		if builder.MaxReferences() {

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -111,7 +111,7 @@ func TestCheckDiff(t *testing.T) {
 	}
 }
 
-func TestProcessDiffs(t *testing.T) {
+func TestProcessDiffs_BuildReferences(t *testing.T) {
 	cases := []struct {
 		name       string
 		sampleBody string
@@ -172,7 +172,7 @@ func TestProcessDiffs(t *testing.T) {
 			name: "modified flag",
 			expected: lflags.FlagsRef{
 				FlagsAdded:   lflags.FlagAliasMap{"example-flag": []string{}},
-				FlagsRemoved: lflags.FlagAliasMap{"example-flag": []string{}},
+				FlagsRemoved: lflags.FlagAliasMap{},
 			},
 			aliases: map[string][]string{},
 			sampleBody: `

--- a/flags/builder.go
+++ b/flags/builder.go
@@ -1,0 +1,95 @@
+package flags
+
+import (
+	"sort"
+	"strings"
+)
+
+type ReferenceBuilder struct {
+	max          int // maximum number of flags to find
+	flagsAdded   map[string][]string
+	flagsRemoved map[string][]string
+	foundFlags   map[string]struct{}
+}
+
+func NewReferenceBuilder(max int) *ReferenceBuilder {
+	return &ReferenceBuilder{
+		flagsAdded:   make(map[string][]string),
+		flagsRemoved: make(map[string][]string),
+		foundFlags:   make(map[string]struct{}),
+	}
+}
+
+func (b *ReferenceBuilder) MaxReferences() bool {
+	return len(b.foundFlags) >= b.max
+}
+
+func (b *ReferenceBuilder) AddReference(flagKey string, op string, aliases []string) {
+	if op == "+" {
+		b.AddedFlag(flagKey, aliases)
+	} else if op == "-" {
+		b.RemovedFlag(flagKey, aliases)
+	}
+	// ignore
+}
+
+func (b *ReferenceBuilder) AddedFlag(flagKey string, aliases []string) {
+	b.foundFlags[flagKey] = struct{}{}
+	if _, ok := b.flagsAdded[flagKey]; !ok {
+		b.flagsAdded[flagKey] = make([]string, 0, len(aliases))
+	}
+	b.flagsAdded[flagKey] = append(b.flagsAdded[flagKey], aliases...)
+}
+
+func (b *ReferenceBuilder) RemovedFlag(flagKey string, aliases []string) {
+	b.foundFlags[flagKey] = struct{}{}
+	if _, ok := b.flagsRemoved[flagKey]; !ok {
+		b.flagsRemoved[flagKey] = make([]string, 0, len(aliases))
+	}
+	b.flagsRemoved[flagKey] = append(b.flagsRemoved[flagKey], aliases...)
+}
+
+func (b *ReferenceBuilder) Build() FlagsRef {
+	added := make(map[string][]string, len(b.flagsAdded))
+	removed := make(map[string][]string, len(b.flagsRemoved))
+
+	for flagKey := range b.foundFlags {
+		if aliases, ok := b.flagsAdded[flagKey]; ok {
+			// if there are any removed aliases, we should add them
+			aliases := append(aliases, b.flagsRemoved[flagKey]...)
+			aliases = uniqueStrs(aliases)
+			sort.Strings(aliases)
+			added[flagKey] = aliases
+		} else if aliases, ok := b.flagsRemoved[flagKey]; ok {
+			// only add to removed if it wasn't also added
+			aliases := uniqueStrs(aliases)
+			sort.Strings(aliases)
+			removed[flagKey] = aliases
+		}
+	}
+
+	return FlagsRef{
+		FlagsAdded:   added,
+		FlagsRemoved: removed,
+	}
+}
+
+// get slice with unique, non-empty strings
+func uniqueStrs(s []string) []string {
+	if len(s) <= 1 {
+		return s
+	}
+	keys := make(map[string]struct{}, len(s))
+	ret := make([]string, 0, len(s))
+	for _, elem := range s {
+		trimmed := strings.TrimSpace(elem)
+		if len(trimmed) == 0 {
+			continue
+		}
+		if _, ok := keys[trimmed]; !ok {
+			keys[trimmed] = struct{}{}
+			ret = append(ret, trimmed)
+		}
+	}
+	return ret
+}

--- a/flags/builder.go
+++ b/flags/builder.go
@@ -17,6 +17,7 @@ func NewReferenceBuilder(max int) *ReferenceBuilder {
 		flagsAdded:   make(map[string][]string),
 		flagsRemoved: make(map[string][]string),
 		foundFlags:   make(map[string]struct{}),
+		max:          max,
 	}
 }
 

--- a/flags/builder.go
+++ b/flags/builder.go
@@ -1,8 +1,11 @@
 package flags
 
 import (
+	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/launchdarkly/find-code-references-in-pull-request/internal/utils"
 )
 
 type ReferenceBuilder struct {
@@ -25,13 +28,17 @@ func (b *ReferenceBuilder) MaxReferences() bool {
 	return len(b.foundFlags) >= b.max
 }
 
-func (b *ReferenceBuilder) AddReference(flagKey string, op string, aliases []string) {
-	if op == "+" {
+func (b *ReferenceBuilder) AddReference(flagKey string, op utils.Operation, aliases []string) error {
+	switch op {
+	case utils.OperationAdd:
 		b.AddedFlag(flagKey, aliases)
-	} else if op == "-" {
+	case utils.OperationDelete:
 		b.RemovedFlag(flagKey, aliases)
+	default:
+		return fmt.Errorf("invalid operation=%s", op.String())
 	}
-	// ignore
+
+	return nil
 }
 
 func (b *ReferenceBuilder) AddedFlag(flagKey string, aliases []string) {

--- a/flags/builder.go
+++ b/flags/builder.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/launchdarkly/find-code-references-in-pull-request/internal/utils"
+	diff_util "github.com/launchdarkly/find-code-references-in-pull-request/internal/util/diff_util"
 )
 
 type ReferenceBuilder struct {
@@ -28,11 +28,11 @@ func (b *ReferenceBuilder) MaxReferences() bool {
 	return len(b.foundFlags) >= b.max
 }
 
-func (b *ReferenceBuilder) AddReference(flagKey string, op utils.Operation, aliases []string) error {
+func (b *ReferenceBuilder) AddReference(flagKey string, op diff_util.Operation, aliases []string) error {
 	switch op {
-	case utils.OperationAdd:
+	case diff_util.OperationAdd:
 		b.AddedFlag(flagKey, aliases)
-	case utils.OperationDelete:
+	case diff_util.OperationDelete:
 		b.RemovedFlag(flagKey, aliases)
 	default:
 		return fmt.Errorf("invalid operation=%s", op.String())

--- a/flags/types.go
+++ b/flags/types.go
@@ -1,8 +1,6 @@
 package flags
 
-type FlagAliasMap = map[string]AliasSet
-
-type AliasSet = map[string]bool
+type FlagAliasMap = map[string][]string
 
 type FlagsRef struct {
 	FlagsAdded   FlagAliasMap

--- a/internal/util/diff_util/operation.go
+++ b/internal/util/diff_util/operation.go
@@ -1,4 +1,4 @@
-package utils
+package diff_util
 
 import "strings"
 

--- a/internal/utils/diff_utils.go
+++ b/internal/utils/diff_utils.go
@@ -1,0 +1,39 @@
+package utils
+
+import "strings"
+
+// Operation defines the operation of a diff item.
+type Operation int
+
+const (
+	// OperationEqual item represents an equals diff.
+	OperationEqual Operation = iota
+	// OperationAdd item represents an insert diff.
+	OperationAdd
+	// OperationDelete item represents a delete diff.
+	OperationDelete
+)
+
+func LineOperation(line string) Operation {
+	if strings.HasPrefix(line, OperationAdd.String()) {
+		return OperationAdd
+	}
+	if strings.HasPrefix(line, OperationDelete.String()) {
+		return OperationDelete
+	}
+
+	return OperationEqual
+}
+
+func (o Operation) String() string {
+	switch o {
+	case OperationAdd:
+		return "+"
+	case OperationDelete:
+		return "-"
+	case OperationEqual:
+		return ""
+	}
+
+	return ""
+}

--- a/main.go
+++ b/main.go
@@ -59,13 +59,15 @@ func main() {
 		FlagsRemoved: make(lflags.FlagAliasMap),
 	}
 
+	builder := lflags.NewReferenceBuilder(config.MaxFlags)
+
 	for _, parsedDiff := range multiFiles {
 		getPath := ldiff.CheckDiff(parsedDiff, config.Workspace)
 		if getPath.Skip {
 			continue
 		}
 		for _, hunk := range parsedDiff.Hunks {
-			ldiff.ProcessDiffs(matcher, hunk, flagsRef, config.MaxFlags)
+			ldiff.ProcessDiffs(matcher, hunk, builder)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -54,13 +54,7 @@ func main() {
 	multiFiles, err := getDiffs(ctx, config, *event.PullRequest.Number)
 	failExit(err)
 
-	flagsRef := lflags.FlagsRef{
-		FlagsAdded:   make(lflags.FlagAliasMap),
-		FlagsRemoved: make(lflags.FlagAliasMap),
-	}
-
 	builder := lflags.NewReferenceBuilder(config.MaxFlags)
-
 	for _, parsedDiff := range multiFiles {
 		getPath := ldiff.CheckDiff(parsedDiff, config.Workspace)
 		if getPath.Skip {
@@ -70,6 +64,7 @@ func main() {
 			ldiff.ProcessDiffs(matcher, hunk, builder)
 		}
 	}
+	flagsRef := builder.Build()
 
 	// Add comment
 	existingComment := checkExistingComments(event, config, ctx)

--- a/testdata/test
+++ b/testdata/test
@@ -1,6 +1,7 @@
 show-widgets
 showWidgets
 betaUi
+betaUi
 show_widgets
 beta_ui
 show-widgets
@@ -8,4 +9,4 @@ old-pricing-banner
 show_widgets
 betaUi
 oldPricingBanner
-betaUi
+oldPricingBanner

--- a/testdata/test
+++ b/testdata/test
@@ -6,7 +6,6 @@ show_widgets
 beta_ui
 show-widgets
 old-pricing-banner
-show_widgets
 betaUi
 oldPricingBanner
 oldPricingBanner


### PR DESCRIPTION
Moves a lot logic out of `ProcessDiffs` by using a builder to track references.

This allows us to use `Build()` to do additional processing that other functions were doing (like deduping added/removed flags as "modified").

This sets us up to handle monorepo support a lot more easily.