### PR TITLE
feat: add support for check extinctions in subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ This action does not support monorepos or searching for flags across LaunchDarkl
 | max-flags | Maximum number of flags to find per PR | `false` | 5 |
 | base-uri | The base URI for the LaunchDarkly server. Most users should use the default value. | `false` | https://app.launchdarkly.com |
 | check-extinctions | Check if removed flags still exist in codebase | `false` | true |
+| check-extinctions-subfolder | If set, subfolder path will be added to GITHUB_WORKSPACE. The extinctions check will happen only in that sub-path. | `false` |  |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: Check if removed flags still exist in codebase
     required: false
     default: 'true'
+  check-extinctions-subfolder:
+    description: If set, subfolder path will be added to GITHUB_WORKSPACE. The extinctions check will happen only in that sub-path.
+    required: false
+    default: ''
 
 outputs:
   any-modified:

--- a/config/config.go
+++ b/config/config.go
@@ -13,21 +13,22 @@ import (
 )
 
 type Config struct {
-	LdProject            string
-	LdEnvironment        string
-	LdInstance           string
-	Owner                string
-	Repo                 string
-	ApiToken             string
-	Workspace            string
-	GHClient             *github.Client
-	MaxFlags             int
-	PlaceholderComment   bool
-	IncludeArchivedFlags bool
-	CheckExtinctions     bool
+	LdProject                 string
+	LdEnvironment             string
+	LdInstance                string
+	Owner                     string
+	Repo                      string
+	ApiToken                  string
+	Workspace                 string
+	GHClient                  *github.Client
+	MaxFlags                  int
+	PlaceholderComment        bool
+	IncludeArchivedFlags      bool
+	CheckExtinctions          bool
+	CheckExtinctionsSubfolder string
 }
 
-func ValidateInputandParse(ctx context.Context) (*Config, error) {
+func ValidateInputAndParse(ctx context.Context) (*Config, error) {
 	// mask tokens
 	if accessToken := os.Getenv("INPUT_ACCESS-TOKEN"); len(accessToken) > 0 {
 		fmt.Printf("::add-mask::%s\n", accessToken)
@@ -89,6 +90,8 @@ func ValidateInputandParse(ctx context.Context) (*Config, error) {
 		// ignore error - default is true
 		config.CheckExtinctions = checkExtinctions
 	}
+
+	config.CheckExtinctionsSubfolder = os.Getenv("INPUT_CHECK-EXTINCTIONS-SUBFOLDER")
 
 	config.GHClient = getGithubClient(ctx)
 	return &config, nil

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -28,7 +29,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	config, err := lcr.ValidateInputandParse(ctx)
+	config, err := lcr.ValidateInputAndParse(ctx)
 	failExit(err)
 
 	eventPath := os.Getenv("GITHUB_EVENT_PATH")
@@ -164,7 +165,7 @@ func getDiffs(ctx context.Context, config *lcr.Config, prNumber int) ([]*diff.Fi
 // Get options from config. Note: dir will be set to workspace
 func getOptions(config *lcr.Config) (options.Options, error) {
 	// Needed for ld-find-code-refs to work as a library
-	viper.Set("dir", config.Workspace)
+	viper.Set("dir", path.Clean(config.Workspace+"/"+config.CheckExtinctionsSubfolder))
 	viper.Set("accessToken", config.ApiToken)
 
 	err := options.InitYAML()


### PR DESCRIPTION
There are limits in https://github.com/launchdarkly/ld-find-code-refs/blob/main/search/search.go#L16-L23
However, if developer writes a helper around feature flagging, it might be possible that check can happen only on one package. 

Then checking all codebase could potentially stops before checking the real code. Targeting directly to that subfolder can avoid false negative.