### PR TITLE
improve messaging for removed flags

### DIFF
--- a/comments/comments.go
+++ b/comments/comments.go
@@ -60,7 +60,7 @@ func githubFlagComment(flag ldapi.FeatureFlag, aliases []string, added, extinct 
 		`{{- end}} | ` +
 		`{{- if eq .Extinct true}} :white_check_mark: all references removed` +
 		`{{- else if eq .ExtinctionsEnabled true}} :warning: not all references removed {{- end}} ` +
-		`{{- if eq .Flag.Archived true}}{{- if eq .Extinct true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}}{{- end}} |`
+		`{{- if eq .Flag.Archived true}}{{- if eq .Extinct true}}<br>{{- else if eq .ExtinctionsEnabled true}}<br>{{end}}{{- if eq .Added true}} :warning:{{else}} :information_source:{{- end}} archived on {{.ArchivedAt | date "2006-01-02"}}{{- end}} |`
 
 	tmpl := template.Must(template.New("comment").Funcs(template.FuncMap{"trim": strings.TrimSpace, "isNil": isNil}).Funcs(sprig.FuncMap()).Parse(tmplSetup))
 	err := tmpl.Execute(&commentBody, commentTemplate)

--- a/comments/comments_test.go
+++ b/comments/comments_test.go
@@ -170,7 +170,7 @@ func (e *testFlagEnv) NoAliases(t *testing.T) {
 	comment, err := githubFlagComment(e.Flag, []string{}, true, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [example flag](https://example.com/test) | `example-flag` | | |"
+	expected := "| [example flag](https://example.com/test) | `example-flag` | | :warning: not all references removed |"
 	assert.Equal(t, expected, comment)
 }
 
@@ -178,7 +178,7 @@ func (e *testFlagEnv) Alias(t *testing.T) {
 	comment, err := githubFlagComment(e.Flag, []string{"exampleFlag", "ExampleFlag"}, true, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [example flag](https://example.com/test) | `example-flag` | `exampleFlag`, `ExampleFlag` | |"
+	expected := "| [example flag](https://example.com/test) | `example-flag` | `exampleFlag`, `ExampleFlag` | :warning: not all references removed |"
 	assert.Equal(t, expected, comment)
 }
 
@@ -186,7 +186,7 @@ func (e *testFlagEnv) ArchivedAdded(t *testing.T) {
 	comment, err := githubFlagComment(e.ArchivedFlag, []string{}, true, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [archived flag](https://example.com/test) | `archived-flag` | | :warning: archived on 2023-08-03 |"
+	expected := "| [archived flag](https://example.com/test) | `archived-flag` | | :warning: not all references removed<br> :warning: archived on 2023-08-03 |"
 	assert.Equal(t, expected, comment)
 }
 
@@ -194,7 +194,7 @@ func (e *testFlagEnv) ArchivedRemoved(t *testing.T) {
 	comment, err := githubFlagComment(e.ArchivedFlag, []string{}, false, false, &e.Config)
 	require.NoError(t, err)
 
-	expected := "| [archived flag](https://example.com/test) | `archived-flag` | | :information_source: archived on 2023-08-03 |"
+	expected := "| [archived flag](https://example.com/test) | `archived-flag` | | :warning: not all references removed<br> :information_source: archived on 2023-08-03 |"
 	assert.Equal(t, expected, comment)
 }
 

--- a/internal/ldclient/flag_links.go
+++ b/internal/ldclient/flag_links.go
@@ -29,7 +29,7 @@ func CreateFlagLinks(config *lcr.Config, flagsRef flags.ReferenceSummary, event 
 	numRemoved := len(flagsRef.FlagsRemoved)
 
 	for key, aliases := range flagsRef.FlagsAdded {
-		message := buildLinkMessage(key, aliases, "added", numAdded, numRemoved)
+		message := buildLinkMessage(aliases, "added", numAdded, numRemoved)
 		link := makeFlagLinkRep(event, key, message)
 		postFlagLink(config, *link, key)
 	}
@@ -39,7 +39,7 @@ func CreateFlagLinks(config *lcr.Config, flagsRef flags.ReferenceSummary, event 
 		if flagsRef.IsExtinct(key) {
 			action = "extinct"
 		}
-		message := buildLinkMessage(key, aliases, action, numAdded, numRemoved)
+		message := buildLinkMessage(aliases, action, numAdded, numRemoved)
 		link := makeFlagLinkRep(event, key, message)
 		postFlagLink(config, *link, key)
 	}
@@ -163,7 +163,7 @@ func getLinkTitle(event *github.PullRequestEvent) *string {
 	return &title
 }
 
-func buildLinkMessage(key string, aliases []string, action string, added, removed int) string {
+func buildLinkMessage(aliases []string, action string, added, removed int) string {
 	builder := new(strings.Builder)
 	builder.WriteString(fmt.Sprintf("Flag %s", action))
 	if len(aliases) > 0 {

--- a/internal/ldclient/flag_links.go
+++ b/internal/ldclient/flag_links.go
@@ -29,7 +29,7 @@ func CreateFlagLinks(config *lcr.Config, flagsRef flags.ReferenceSummary, event 
 	numRemoved := len(flagsRef.FlagsRemoved)
 
 	for key, aliases := range flagsRef.FlagsAdded {
-		message := buildLinkMessage(aliases, "added", numAdded, numRemoved)
+		message := buildLinkMessage(key, aliases, "added", numAdded, numRemoved)
 		link := makeFlagLinkRep(event, key, message)
 		postFlagLink(config, *link, key)
 	}
@@ -39,7 +39,7 @@ func CreateFlagLinks(config *lcr.Config, flagsRef flags.ReferenceSummary, event 
 		if flagsRef.IsExtinct(key) {
 			action = "extinct"
 		}
-		message := buildLinkMessage(aliases, action, numAdded, numRemoved)
+		message := buildLinkMessage(key, aliases, action, numAdded, numRemoved)
 		link := makeFlagLinkRep(event, key, message)
 		postFlagLink(config, *link, key)
 	}
@@ -163,7 +163,7 @@ func getLinkTitle(event *github.PullRequestEvent) *string {
 	return &title
 }
 
-func buildLinkMessage(aliases []string, action string, added, removed int) string {
+func buildLinkMessage(key string, aliases []string, action string, added, removed int) string {
 	builder := new(strings.Builder)
 	builder.WriteString(fmt.Sprintf("Flag %s", action))
 	if len(aliases) > 0 {

--- a/testdata/test
+++ b/testdata/test
@@ -1,7 +1,6 @@
 show-widgets
 showWidgets
 show_widgets
-show-widgets
 oldPricingBanner
 show_widgets
 oldPricingBanner


### PR DESCRIPTION
Make it clearer if a removed flag still has instances in the codebase

![CleanShot 2024-03-20 at 11 45 00](https://github.com/launchdarkly/find-code-references-in-pull-request/assets/4053924/02e5bd95-e650-4e3c-9fc8-034b6752b2d1)
