### PR TITLE
setup go before running pre-commit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+        with:
+          go-version-file: go.mod
+
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
@@ -32,11 +37,6 @@ jobs:
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
-
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
-        with:
-          go-version-file: go.mod
 
       - name: Install dependencies
         run: go mod tidy


### PR DESCRIPTION
#159 is complaining about golangci-lint version doesn't match target version. I think this is because we need to setup go before running pre-commit, so I moved the setup go step above the pre-commit step to see what will happen