### PR TITLE
docs(readme): add note in README about creating the "ld-flags" label first

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ jobs:
           access-token: ${{ secrets.LD_ACCESS_TOKEN }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Add or remove labels on PRs if any flags have changed
+      # Add or remove labels on PRs if any flags have changed.
+      # Note: This example requires the "ld-flags" label to have been created in the repository first:
+      # https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#creating-a-label
       - name: Add label
         if: steps.find-flags.outputs.any-changed == 'true'
         run: gh pr edit $PR_NUMBER --add-label ld-flags


### PR DESCRIPTION
Cherry-pick https://github.com/launchdarkly/find-code-references-in-pull-request/commit/bfc5b6b84965f8f563480500a7b77ef32773c1b3 from #173. Github actions isn't happy with running the end-to-end tests in a fork of this repo, but this should work around it for now 🤞 