### PR TITLE
Update CODEOWNERS: rename team-fm-next to team-fm-foundations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 
-* @launchdarkly/team-fm-next
+* @launchdarkly/team-fm-foundations


### PR DESCRIPTION
## Summary

Renames the CODEOWNERS team reference from `@launchdarkly/team-fm-next` to `@launchdarkly/team-fm-foundations` to reflect the team's new name. This is part of a batch update across multiple repos in the org.

## Review & Testing Checklist for Human
- [ ] Verify that the GitHub team `@launchdarkly/team-fm-foundations` exists and has the expected members
- [ ] Confirm no other references to `team-fm-next` remain in this repo outside of CODEOWNERS (e.g., CI configs, docs)

### Notes
- This repo's CODEOWNERS only had a single reference to the old team name.
- Part of an org-wide rename affecting multiple repositories.

Link to Devin session: https://app.devin.ai/sessions/8abe80d07e414755864c1b9c67215686
Requested by: @kparkinson-ld