### PR TITLE
fix: guard checkDiffFile against mode-only diffs with empty OrigName/NewName

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -41,6 +41,11 @@ func checkDiffFile(parsedDiff *diff.FileDiff, workspace string) (filePath string
 	// If file is being renamed we don't want to check it for flags.
 	parsedFileA := strings.SplitN(parsedDiff.OrigName, "/", 2)
 	parsedFileB := strings.SplitN(parsedDiff.NewName, "/", 2)
+	// Mode-only diffs (e.g. chmod changes) and some binary diffs emit no --- / +++ headers.
+	// go-diff returns empty OrigName/NewName for these entries; there is no content to scan.
+	if len(parsedFileA) < 2 || len(parsedFileB) < 2 {
+		return "", true
+	}
 	fullPathToA := workspace + "/" + parsedFileA[1]
 	fullPathToB := workspace + "/" + parsedFileB[1]
 	info, err := os.Stat(fullPathToB)

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -69,11 +69,12 @@ func newProcessFlagAccEnv() *testProcessor {
 
 func Test_checkDiffFile(t *testing.T) {
 	cases := []struct {
-		name     string
-		fileName string
-		origName string
-		newName  string
-		skip     bool
+		name             string
+		fileName         string
+		origName         string
+		newName          string
+		skip             bool
+		expectedFilePath string // when non-empty, overrides "../testdata/" + fileName
 	}{
 		{
 			name:     "basic",
@@ -89,6 +90,16 @@ func Test_checkDiffFile(t *testing.T) {
 			newName:  "b/.testignore",
 			skip:     true,
 		},
+		{
+			// Mode-only diffs (e.g. chmod changes) produce no --- / +++ headers.
+			// go-diff returns empty OrigName and NewName for these entries, which
+			// caused a panic at diff.go:44 when SplitN("", "/", 2)[1] was accessed.
+			name:             "skip mode-only diff with empty OrigName and NewName",
+			origName:         "",
+			newName:          "",
+			skip:             true,
+			expectedFilePath: "",
+		},
 	}
 
 	for _, tc := range cases {
@@ -100,13 +111,16 @@ func Test_checkDiffFile(t *testing.T) {
 				OrigStartLine: 0,
 				StartPosition: 1,
 			}
-			diff := diff.FileDiff{
+			fileDiff := diff.FileDiff{
 				OrigName: tc.origName,
 				NewName:  tc.newName,
 				Hunks:    []*diff.Hunk{hunk},
 			}
-			filePath, ignore := checkDiffFile(&diff, "../testdata")
-			expectedFilePath := "../testdata/" + tc.fileName
+			filePath, ignore := checkDiffFile(&fileDiff, "../testdata")
+			expectedFilePath := tc.expectedFilePath
+			if expectedFilePath == "" && tc.fileName != "" {
+				expectedFilePath = "../testdata/" + tc.fileName
+			}
 			assert.Equal(t, expectedFilePath, filePath)
 			assert.Equal(t, tc.skip, ignore)
 		})


### PR DESCRIPTION
## Problem

The action panics with `index out of range [1] with length 1` at `diff/diff.go:44` when a pull request contains a file whose **only change is a permission/mode bit** (no content diff). The bug is present in both v2.0.0 and v2.1.0.

### Root cause

`checkDiffFile` splits `OrigName` and `NewName` on `/` and unconditionally accesses `[1]`:

```go
parsedFileA := strings.SplitN(parsedDiff.OrigName, "/", 2)
parsedFileB := strings.SplitN(parsedDiff.NewName, "/", 2)
fullPathToA := workspace + "/" + parsedFileA[1]   // line 44 — PANICS
fullPathToB := workspace + "/" + parsedFileB[1]
```

For a standard git diff, file names always carry an `a/` or `b/` prefix (or are `/dev/null`), so `SplitN` returns two elements. **Mode-only diffs have no `---` / `+++` headers at all.** The `sourcegraph/go-diff` parser therefore returns `OrigName = ""` and `NewName = ""` for those entries:

```go
strings.SplitN("", "/", 2)  // [""] — length 1, not 2
```

Accessing `[1]` on a single-element slice is a runtime panic.

### How to reproduce

Open a PR containing a file whose only change is the execute bit:

```bash
git checkout -b repro/mode-change
chmod -x some-file.yaml        # was 100755, becomes 100644
git add some-file.yaml
git commit -m "chore: remove execute bit"
git push origin repro/mode-change
# open PR — the action panics during "Preprocessing diffs..."
```

The diff block that triggers it (no `---` / `+++` lines):

```diff
diff --git a/some-file.yaml b/some-file.yaml
old mode 100755
new mode 100644
```

The resulting panic:

```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/launchdarkly/find-code-references-in-pull-request/diff.checkDiffFile(...)
        /app/diff/diff.go:44 +0x46a
github.com/launchdarkly/find-code-references-in-pull-request/diff.PreprocessDiffs(...)
        /app/diff/diff.go:21 +0x9d
main.main()
        /app/main.go:60 +0x4c5
```

> Note: the `stat: no such file or directory` line printed just before the panic is from a **separate, preceding file** processed normally — it is not the file that causes the crash.

## Fix

Add a length guard before indexing. Mode-only and header-less diffs have no content to scan, so returning `ignore = true` is the correct behaviour:

```go
if len(parsedFileA) < 2 || len(parsedFileB) < 2 {
    return "", true
}
```

---

🤖 This PR was created with the assistance of [Claude Code](https://claude.ai/code)