### PR TITLE
Fix false flag removals when max-flags stops mid-file scan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,8 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,8 +78,8 @@ jobs:
         uses: ./ # Uses an action in the root directory
         id: find-flags
         with:
-          project-key: demo-dan-042021-2
-          environment-key: development
+          project-key: developer-toolbar-sandbox
+          environment-key: test
           access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           base-uri: https://app.launchdarkly.com

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -69,6 +69,10 @@ func checkDiffFile(parsedDiff *diff.FileDiff, workspace string) (filePath string
 }
 
 func ProcessDiffs(matcher lsearch.Matcher, contents []byte, builder *refs.ReferenceSummaryBuilder) {
+	if builder.MaxReferences() {
+		return
+	}
+
 	diffLines := strings.Split(string(contents), "\n")
 	for _, line := range diffLines {
 		op := diff_util.LineOperation(line)
@@ -85,9 +89,6 @@ func ProcessDiffs(matcher lsearch.Matcher, contents []byte, builder *refs.Refere
 			if err != nil {
 				fmt.Println(err)
 			}
-		}
-		if builder.MaxReferences() {
-			break
 		}
 	}
 }

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -249,3 +249,45 @@ func TestProcessDiffs_BuildReferences(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessDiffs_finishesFileBeforeMaxFlagsCap(t *testing.T) {
+	processor := newProcessFlagAccEnv()
+	processor.Builder = refs.NewReferenceSummaryBuilder(1, false)
+
+	elements := []lsearch.ElementMatcher{
+		lsearch.NewElementMatcher("default", "", "", processor.flagKeys(), map[string][]string{}),
+	}
+	matcher := lsearch.Matcher{Elements: elements}
+
+	// With max-flags=1, an early mid-file stop would classify example-flag as removed
+	// before the re-add line is scanned.
+	body := `
+-example-flag
++example-flag
++sample-flag
+`
+	ProcessDiffs(matcher, []byte(body), processor.Builder)
+	flagsRef := processor.Builder.Build()
+
+	assert.Contains(t, flagsRef.FlagsAdded, "example-flag")
+	assert.NotContains(t, flagsRef.FlagsRemoved, "example-flag")
+}
+
+func TestProcessDiffs_skipsSubsequentFilesAtMaxFlags(t *testing.T) {
+	processor := newProcessFlagAccEnv()
+	processor.Builder = refs.NewReferenceSummaryBuilder(1, false)
+
+	elements := []lsearch.ElementMatcher{
+		lsearch.NewElementMatcher("default", "", "", processor.flagKeys(), map[string][]string{}),
+	}
+	matcher := lsearch.Matcher{Elements: elements}
+
+	ProcessDiffs(matcher, []byte("+example-flag\n"), processor.Builder)
+	assert.True(t, processor.Builder.MaxReferences())
+
+	ProcessDiffs(matcher, []byte("+sample-flag\n"), processor.Builder)
+	flagsRef := processor.Builder.Build()
+
+	assert.Contains(t, flagsRef.FlagsAdded, "example-flag")
+	assert.NotContains(t, flagsRef.FlagsAdded, "sample-flag")
+}

--- a/internal/references/builder.go
+++ b/internal/references/builder.go
@@ -8,6 +8,11 @@ import (
 	"github.com/launchdarkly/find-code-references-in-pull-request/internal/utils/diff_util"
 )
 
+type refCounts struct {
+	adds    int
+	deletes int
+}
+
 type ReferenceSummaryBuilder struct {
 	max                int  // maximum number of flags to find
 	includeExtinctions bool // include extinctions in summary
@@ -15,6 +20,7 @@ type ReferenceSummaryBuilder struct {
 	flagsRemoved       map[string][]string
 	flagsFoundAtHead   map[string]struct{}
 	foundFlags         map[string]struct{}
+	counts             map[string]refCounts
 }
 
 func NewReferenceSummaryBuilder(max int, includeExtinctions bool) *ReferenceSummaryBuilder {
@@ -23,6 +29,7 @@ func NewReferenceSummaryBuilder(max int, includeExtinctions bool) *ReferenceSumm
 		flagsRemoved:       make(map[string][]string),
 		foundFlags:         make(map[string]struct{}),
 		flagsFoundAtHead:   make(map[string]struct{}),
+		counts:             make(map[string]refCounts),
 		max:                max,
 		includeExtinctions: includeExtinctions,
 	}
@@ -62,6 +69,9 @@ func (b *ReferenceSummaryBuilder) foundFlag(flagKey string) {
 // Flag and aliases found in added diff
 func (b *ReferenceSummaryBuilder) addedFlag(flagKey string, aliases []string) {
 	b.foundFlag(flagKey)
+	counts := b.counts[flagKey]
+	counts.adds++
+	b.counts[flagKey] = counts
 	if _, ok := b.flagsAdded[flagKey]; !ok {
 		b.flagsAdded[flagKey] = make([]string, 0, len(aliases))
 	}
@@ -71,6 +81,9 @@ func (b *ReferenceSummaryBuilder) addedFlag(flagKey string, aliases []string) {
 // Flag and aliases found in removed diff
 func (b *ReferenceSummaryBuilder) removedFlag(flagKey string, aliases []string) {
 	b.foundFlag(flagKey)
+	counts := b.counts[flagKey]
+	counts.deletes++
+	b.counts[flagKey] = counts
 	if _, ok := b.flagsRemoved[flagKey]; !ok {
 		b.flagsRemoved[flagKey] = make([]string, 0, len(aliases))
 	}
@@ -80,8 +93,10 @@ func (b *ReferenceSummaryBuilder) removedFlag(flagKey string, aliases []string) 
 // Returns a list of removed flag keys
 func (b *ReferenceSummaryBuilder) RemovedFlagKeys() []string {
 	keys := make([]string, 0, len(b.flagsRemoved))
-	for k := range b.flagsRemoved {
-		keys = append(keys, k)
+	for k, counts := range b.counts {
+		if counts.deletes > 0 && counts.adds == 0 {
+			keys = append(keys, k)
+		}
 	}
 	return keys
 }
@@ -92,15 +107,15 @@ func (b *ReferenceSummaryBuilder) Build() ReferenceSummary {
 	extinctions := make(map[string]struct{}, len(b.flagsRemoved))
 
 	for flagKey := range b.foundFlags {
-		if aliases, ok := b.flagsAdded[flagKey]; ok {
-			// if there are any removed aliases, we should add them
-			aliases := append(aliases, b.flagsRemoved[flagKey]...)
+		counts := b.counts[flagKey]
+		switch {
+		case counts.adds > 0:
+			aliases := append(b.flagsAdded[flagKey], b.flagsRemoved[flagKey]...)
 			aliases = uniqueStrs(aliases)
 			sort.Strings(aliases)
 			added[flagKey] = aliases
-		} else if aliases, ok := b.flagsRemoved[flagKey]; ok {
-			// only add to removed if it wasn't also added
-			aliases := uniqueStrs(aliases)
+		case counts.deletes > 0:
+			aliases := uniqueStrs(b.flagsRemoved[flagKey])
 			sort.Strings(aliases)
 			removed[flagKey] = aliases
 			if _, ok := b.flagsFoundAtHead[flagKey]; !ok {

--- a/internal/references/builder_test.go
+++ b/internal/references/builder_test.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"testing"
 
+	"github.com/launchdarkly/find-code-references-in-pull-request/internal/utils/diff_util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,6 +27,12 @@ func TestBuilder_Build(t *testing.T) {
 			"flag3": {},
 			"flag4": {},
 		},
+		counts: map[string]refCounts{
+			"flag1": {adds: 1},
+			"flag2": {adds: 1, deletes: 1},
+			"flag3": {deletes: 1},
+			"flag4": {deletes: 1},
+		},
 		includeExtinctions: true,
 	}
 
@@ -34,6 +41,7 @@ func TestBuilder_Build(t *testing.T) {
 	assert.Len(t, built.FlagsAdded, 2)
 	assert.Len(t, built.FlagsRemoved, 2)
 	assert.Len(t, built.ExtinctFlags, 1)
+	assert.NotContains(t, built.FlagsRemoved, "flag2")
 }
 
 func TestBuilder_RemovedFlagKeys(t *testing.T) {
@@ -56,11 +64,29 @@ func TestBuilder_RemovedFlagKeys(t *testing.T) {
 			"flag3": {},
 			"flag4": {},
 		},
+		counts: map[string]refCounts{
+			"flag1": {adds: 1},
+			"flag2": {adds: 1, deletes: 1},
+			"flag3": {deletes: 1},
+			"flag4": {deletes: 1},
+		},
 		includeExtinctions: true,
 	}
 
 	keys := ref.RemovedFlagKeys()
 
-	assert.Len(t, keys, 3)
-	assert.ElementsMatch(t, keys, []string{"flag2", "flag3", "flag4"})
+	assert.Len(t, keys, 2)
+	assert.ElementsMatch(t, keys, []string{"flag3", "flag4"})
+}
+
+func TestBuilder_Build_netZeroChurnIsModified(t *testing.T) {
+	builder := NewReferenceSummaryBuilder(5, false)
+	assert.NoError(t, builder.AddReference("my-flag", diff_util.OperationDelete, nil))
+	assert.NoError(t, builder.AddReference("my-flag", diff_util.OperationAdd, nil))
+
+	built := builder.Build()
+
+	assert.Contains(t, built.FlagsAdded, "my-flag")
+	assert.NotContains(t, built.FlagsRemoved, "my-flag")
+	assert.Empty(t, builder.RemovedFlagKeys())
 }


### PR DESCRIPTION
Finish scanning each diff file before applying the cap, and classify flags by net +/- counts so delete-then-re-add churn is reported as modified instead of removed.