### PR TITLE
feat: add opt-in /docker entry point with published runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+.cursor
+*.md
+images
+testdata
+.pre-commit-config.yaml
+.gitignore
+.DS_Store

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,17 +230,25 @@ jobs:
             exit 1
           fi
 
+  e2e-docker-fail-loud-workspace:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Clear GITHUB_WORKSPACE for next step
+        run: echo "GITHUB_WORKSPACE=" >> "$GITHUB_ENV"
+
       - name: Fail-loud missing workspace
         id: missing-ws
         continue-on-error: true
         uses: ./docker
-        env:
-          GITHUB_WORKSPACE: ""
         with:
           access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           skip-comment: true
-          dockerImage: ${{ env.MIRRORED_IMAGE }}
+          dockerImage: alpine:3.21
 
       - name: Assert missing workspace failed
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,34 +230,6 @@ jobs:
             exit 1
           fi
 
-  e2e-docker-fail-loud-workspace:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Clear GITHUB_WORKSPACE for next step
-        run: echo "GITHUB_WORKSPACE=" >> "$GITHUB_ENV"
-
-      - name: Fail-loud missing workspace
-        id: missing-ws
-        continue-on-error: true
-        uses: ./docker
-        with:
-          access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-comment: true
-          dockerImage: alpine:3.21
-
-      - name: Assert missing workspace failed
-        run: |
-          set -euo pipefail
-          if [[ "${{ steps.missing-ws.outcome }}" != "failure" ]]; then
-            echo "expected missing GITHUB_WORKSPACE to fail"
-            exit 1
-          fi
-
   generate-docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,136 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-  
+
+  e2e-docker-entrypoint:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Build local runtime image
+        run: |
+          set -euo pipefail
+          docker build -t fcr-pr-local:${{ github.sha }} .
+          docker run --rm fcr-pr-local:${{ github.sha }} git --version
+
+      - name: Root Action (control)
+        id: root
+        uses: ./
+        with:
+          project-key: developer-toolbar-sandbox
+          environment-key: test
+          access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          base-uri: https://app.launchdarkly.com
+          max-flags: 200
+          create-flag-links: false
+          skip-comment: true
+
+      - name: /docker Action (local image)
+        id: docker-local
+        uses: ./docker
+        with:
+          project-key: developer-toolbar-sandbox
+          environment-key: test
+          access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          base-uri: https://app.launchdarkly.com
+          max-flags: 200
+          create-flag-links: false
+          skip-comment: true
+          dockerImage: fcr-pr-local:${{ github.sha }}
+
+      - name: Assert output parity
+        run: |
+          set -euo pipefail
+          echo "root any-changed=${{ steps.root.outputs.any-changed }} count=${{ steps.root.outputs.changed-flags-count }}"
+          echo "docker any-changed=${{ steps.docker-local.outputs.any-changed }} count=${{ steps.docker-local.outputs.changed-flags-count }}"
+          if [[ "${{ steps.root.outputs.any-changed }}" != "${{ steps.docker-local.outputs.any-changed }}" ]]; then
+            echo "any-changed mismatch"
+            exit 1
+          fi
+          if [[ "${{ steps.root.outputs.changed-flags-count }}" != "${{ steps.docker-local.outputs.changed-flags-count }}" ]]; then
+            echo "changed-flags-count mismatch"
+            exit 1
+          fi
+
+      - name: Mirror image to GHCR
+        run: |
+          set -euo pipefail
+          DEST=ghcr.io/${{ github.repository }}:${{ github.sha }}
+          docker tag fcr-pr-local:${{ github.sha }} "$DEST"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          docker push "$DEST"
+          # Drop local tags so the next step must pull from GHCR.
+          docker image rm "$DEST" fcr-pr-local:${{ github.sha }}
+          echo "MIRRORED_IMAGE=$DEST" >> "$GITHUB_ENV"
+
+      - name: /docker Action (GHCR mirror)
+        id: docker-mirror
+        uses: ./docker
+        with:
+          project-key: developer-toolbar-sandbox
+          environment-key: test
+          access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          base-uri: https://app.launchdarkly.com
+          max-flags: 200
+          create-flag-links: false
+          skip-comment: true
+          dockerImage: ${{ env.MIRRORED_IMAGE }}
+
+      - name: Assert mirror outputs
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.root.outputs.any-changed }}" != "${{ steps.docker-mirror.outputs.any-changed }}" ]]; then
+            echo "mirror any-changed mismatch"
+            exit 1
+          fi
+
+      - name: Fail-loud empty dockerImage
+        id: empty-image
+        continue-on-error: true
+        uses: ./docker
+        with:
+          access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-comment: true
+          dockerImage: ""
+
+      - name: Assert empty dockerImage failed
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.empty-image.outcome }}" != "failure" ]]; then
+            echo "expected empty dockerImage to fail"
+            exit 1
+          fi
+
+      - name: Fail-loud missing workspace
+        id: missing-ws
+        continue-on-error: true
+        uses: ./docker
+        env:
+          GITHUB_WORKSPACE: ""
+        with:
+          access-token: ${{ secrets.LD_ACCESS_TOKEN_WRITER }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          skip-comment: true
+          dockerImage: ${{ env.MIRRORED_IMAGE }}
+
+      - name: Assert missing workspace failed
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.missing-ws.outcome }}" != "failure" ]]; then
+            echo "expected missing GITHUB_WORKSPACE to fail"
+            exit 1
+          fi
+
   generate-docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           set -euo pipefail
           docker build -t fcr-pr-local:${{ github.sha }} .
-          docker run --rm fcr-pr-local:${{ github.sha }} git --version
+          docker run --rm --entrypoint git fcr-pr-local:${{ github.sha }} --version
 
       - name: Root Action (control)
         id: root

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,71 @@
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Image tag without v prefix (e.g. 2.3.0)
+        required: true
+        type: string
+      push_latest:
+        description: Also tag and push latest
+        required: false
+        type: boolean
+        default: true
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Resolve version
+        id: version
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ inputs.version }}"
+            PUSH_LATEST="${{ inputs.push_latest }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+            PUSH_LATEST="true"
+          fi
+          if [[ -z "${VERSION}" || "${VERSION}" == v* ]]; then
+            echo "Invalid version: ${VERSION}"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "push_latest=${PUSH_LATEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: launchdarkly/find-code-references-in-pull-request
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ steps.version.outputs.push_latest }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -45,17 +45,17 @@ jobs:
           echo "push_latest=${PUSH_LATEST}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: launchdarkly/find-code-references-in-pull-request
           tags: |
@@ -63,7 +63,7 @@ jobs:
             type=raw,value=latest,enable=${{ steps.version.outputs.push_latest }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           push: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ config → LD flags → PR diff → preprocess → match → summarize → outpu
 
 | Package / path | Role |
 | --- | --- |
-| `action.yml` + `Dockerfile` | Action contract and container entrypoint |
+| `action.yml` + `Dockerfile` | Root Action contract and container build (multi-stage; final image has binary + `git`) |
+| `docker/action.yml` | Opt-in composite entry point with `dockerImage` override (`docker run`) |
 | `config/` | Parse/validate `INPUT_*` env vars; GitHub client (incl. GHE) |
 | `diff/` | Preprocess PR diffs; ignore paths; scan hunks into the builder |
 | `search/` | Build matcher via `ld-find-code-refs` + alias generation |
@@ -115,7 +116,7 @@ Do not add reviewers; CODEOWNERS / maintainers handle that ([CONTRIBUTING.md](CO
 
 ### Fork PRs and CI
 
-- Same-repo PRs: `.github/workflows/main.yml` runs `go-test`, `e2e-tests` (needs secrets), and `generate-docs`.
+- Same-repo PRs: `.github/workflows/main.yml` runs `go-test`, `e2e-tests` (needs secrets), `e2e-docker-entrypoint` (local + GHCR mirror `/docker` path), and `generate-docs`.
 - Fork PRs: secret-dependent jobs are skipped on `pull_request`. Maintainers add the **`safe-to-test`** label to run `.github/workflows/test-fork-pr.yml` (`pull_request_target`). `.github/workflows/remove-safe-to-test-label.yml` strips the label on new pushes — do not “fix around” that security gate.
 - e2e uses this action against itself (`uses: ./`) with sandbox project credentials.
 
@@ -125,8 +126,12 @@ Follow [DEVELOPMENT.md](DEVELOPMENT.md):
 
 1. Move `[Unreleased]` notes into a new version section in `CHANGELOG.md`
 2. Set `internal/version/version.go` to match
-3. Publish via GitHub Marketplace release flow (manual publish step)
-4. Maintain major floating tag (`v2` for 2.x) in addition to semver tags
+3. Bump default `dockerImage` in `docker/action.yml` (+ README pins) to the new semver
+4. Publish via GitHub Marketplace release flow (manual publish step)
+5. Maintain major floating tag (`v2` for 2.x) in addition to semver tags
+6. Publish the runtime image `launchdarkly/find-code-references-in-pull-request:X.Y.Z` via `.github/workflows/publish-image.yml` (tag push or `workflow_dispatch`; needs `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`)
+
+Optional follow-up: thin the root `Dockerfile` to `FROM` that published image so default `@v2` users also skip compile-on-run.
 
 ## Security and boundaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- optional GitHub Action entry point `launchdarkly/find-code-references-in-pull-request/docker` with a `dockerImage` input so workflows can pull a prebuilt runtime image from a private registry or Docker Hub proxy. The root Action is unchanged.
+- multi-stage `Dockerfile` and Docker Hub publish workflow for `launchdarkly/find-code-references-in-pull-request` runtime images
+
 ### Changed
 
 ### Fixed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,11 +19,18 @@ _Read more: [Example commands](https://github.com/nektos/act#example-commands)_
 
 ## Publishing a release
 
-Make sure [CHANGELOG.md](CHANGELOG.md) and [version](internal/version/version.go) are updated
+1. Move `[Unreleased]` notes into a new version section in [CHANGELOG.md](CHANGELOG.md)
+2. Set [internal/version/version.go](internal/version/version.go) to match
+3. Update the default `dockerImage` tag in [docker/action.yml](docker/action.yml) (and README examples) to the new semver
+4. Create the GitHub release / Marketplace publish (manual publish step — see [GitHub docs](https://docs.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace#publishing-an-action))
+5. Maintain the major floating tag (`v2` for 2.x) in addition to the semver tag
+6. Publish the runtime Docker image to Docker Hub (required for the optional `/docker` entry point):
+   - Prefer tagging `vX.Y.Z` on `main` (triggers [.github/workflows/publish-image.yml](.github/workflows/publish-image.yml)), **or**
+   - Run **Publish Docker image** via `workflow_dispatch` with `version: X.Y.Z`
+   - Repo secrets required: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
+   - Image: `launchdarkly/find-code-references-in-pull-request:X.Y.Z` (and `latest` when enabled)
 
-Follow instructions to [publish a release to the GitHub Marketplace](https://docs.github.com/en/actions/creating-actions/publishing-actions-in-github-marketplace#publishing-an-action).
-
-**Publishing** is a manual step even if automation is used to create a release.
+**Publishing** to the Marketplace is a manual step even if automation is used to create a release.
 
 ### Versioning
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
-FROM golang:alpine
+FROM golang:alpine AS builder
+
+RUN apk add --no-cache git
+
+WORKDIR /app
+COPY . .
+ENV GO111MODULE=on
+RUN go build -mod=vendor -o /find-code-references-in-pull-request .
+
+FROM alpine:3.21
+
 LABEL com.github.actions.name="LaunchDarkly Find Flags"
 LABEL com.github.actions.description="Flags"
 LABEL homepage="https://www.launchdarkly.com"
 
-RUN apk update
 RUN apk add --no-cache git
 
-RUN mkdir /app
-WORKDIR /app
-COPY . .
-ENV GO111MODULE=on
-RUN go mod download
-RUN go build .
+COPY --from=builder /find-code-references-in-pull-request /find-code-references-in-pull-request
 
-
-
-ENTRYPOINT ["/app/find-code-references-in-pull-request"]
+ENTRYPOINT ["/find-code-references-in-pull-request"]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,42 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
 ```
 
+## Using a private or mirrored container registry
+
+The root Action (`launchdarkly/find-code-references-in-pull-request@v2`) is a Docker container action. GitHub builds its `Dockerfile` on each run (which pulls base images from Docker Hub), and that image reference cannot be overridden with an input.
+
+If your organization must pull images through an internal registry or Docker Hub proxy, use the optional **`docker`** entry point. It runs a **prebuilt** runtime image via `docker run` and accepts a `dockerImage` input. Mirror `launchdarkly/find-code-references-in-pull-request` into your registry first (pin the tag you mirrored).
+
+```yaml
+on: pull_request
+
+jobs:
+  find-flags:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: your.registry.example
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Find flags
+        id: find-flags
+        # Pin to a release that includes the docker/ entry point and published image (see changelog).
+        uses: launchdarkly/find-code-references-in-pull-request/docker@v2.3.0
+        with:
+          project-key: default
+          environment-key: production
+          access-token: ${{ secrets.LD_ACCESS_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          dockerImage: your.registry.example/launchdarkly/find-code-references-in-pull-request:2.3.0
+```
+
+This entry point requires a Docker CLI on the runner (included on GitHub-hosted `ubuntu-*` runners). Existing workflows that use the root Action do not need to change.
+
 ### Flag aliases
 
 This action has full support for code reference aliases. If the project has an existing [`.launchdarkly/coderefs.yaml`](https://github.com/launchdarkly/ld-find-code-refs/blob/main/docs/CONFIGURATION.md#yaml) file, it will use the aliases defined there.

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -1,0 +1,191 @@
+name: "LaunchDarkly Code References in Pull Request (custom image)"
+description: >-
+  Find references to feature flags in your pull request. Same scanner as the
+  root Action, but runs via docker run so you can override the image registry
+  (for example an internal Docker Hub proxy).
+author: LaunchDarkly
+branding:
+  icon: toggle-right
+  color: gray-dark
+
+inputs:
+  repo-token:
+    description: "Token to use to authorize comments on PR. Typically the `GITHUB_TOKEN` secret or equivalent `github.token`."
+    required: true
+  access-token:
+    description: LaunchDarkly access token
+    required: true
+  project-key:
+    description: LaunchDarkly project key
+    required: false
+    default: "default"
+  environment-key:
+    description: LaunchDarkly environment key for creating flag links
+    required: false
+    default: "production"
+  placeholder-comment:
+    description: Comment on PR when no flags are found. If flags are found in later commits, this comment will be updated.
+    required: false
+    default: "false"
+  include-archived-flags:
+    description: Scan for archived flags
+    required: false
+    default: "true"
+  max-flags:
+    description: Maximum number of flags to find per PR
+    required: false
+    default: "5"
+  base-uri:
+    description: The base URI for the LaunchDarkly server. Most members should use the default value.
+    required: false
+    default: "https://app.launchdarkly.com"
+  check-extinctions:
+    description: Check if removed flags still exist in codebase
+    required: false
+    default: "true"
+  create-flag-links:
+    description: Create links to flags in LaunchDarkly. To use this feature you must use an access token with the `createFlagLink` role. To learn more, read [Flag links](https://docs.launchdarkly.com/home/organize/links).
+    required: false
+    default: "true"
+  skip-comment:
+    description: Skip commenting on PR. If set to true, the action will not comment on the PR, but will still set outputs.
+    required: false
+    default: "false"
+  dockerImage:
+    description: >-
+      Container image to run. Defaults to the public Docker Hub runtime image.
+      Set this to your mirrored/proxy image (for example
+      your.registry.example/launchdarkly/find-code-references-in-pull-request:2.3.0).
+      Authenticate to private registries with docker/login-action (or equivalent)
+      in a prior step. Requires a runner with a Docker CLI (GitHub-hosted
+      ubuntu-* runners include one).
+    required: false
+    default: "launchdarkly/find-code-references-in-pull-request:2.3.0"
+
+outputs:
+  any-modified:
+    description: Returns true if any flags have been added or modified in PR
+    value: ${{ steps.run.outputs.any-modified }}
+  modified-flags:
+    description: Space-separated list of flags added or modified in PR
+    value: ${{ steps.run.outputs.modified-flags }}
+  modified-flags-count:
+    description: Number of flags added or modified in PR
+    value: ${{ steps.run.outputs.modified-flags-count }}
+  any-removed:
+    description: Returns true if any flags have been removed in PR
+    value: ${{ steps.run.outputs.any-removed }}
+  removed-flags:
+    description: Space-separated list of flags removed in PR
+    value: ${{ steps.run.outputs.removed-flags }}
+  removed-flags-count:
+    description: Number of flags removed in PR
+    value: ${{ steps.run.outputs.removed-flags-count }}
+  any-changed:
+    description: Returns true if any flags have been changed in PR
+    value: ${{ steps.run.outputs.any-changed }}
+  changed-flags:
+    description: Space-separated list of flags changed in PR
+    value: ${{ steps.run.outputs.changed-flags }}
+  changed-flags-count:
+    description: Number of flags changed in PR
+    value: ${{ steps.run.outputs.changed-flags-count }}
+  any-extinct:
+    description: Returns true if any flags have been removed in PR and no longer exist in codebase. Only returned if `check-extinctions` is true.
+    value: ${{ steps.run.outputs.any-extinct }}
+  extinct-flags:
+    description: Space-separated list of flags removed in PR and no longer exist in codebase. Only returned if `check-extinctions` is true.
+    value: ${{ steps.run.outputs.extinct-flags }}
+  extinct-flags-count:
+    description: Number of flags removed in PR and no longer exist in codebase. Only returned if `check-extinctions` is true.
+    value: ${{ steps.run.outputs.extinct-flags-count }}
+
+runs:
+  using: composite
+  steps:
+    - name: Run LaunchDarkly Code References in Pull Request
+      id: run
+      shell: bash
+      env:
+        DOCKER_IMAGE: ${{ inputs.dockerImage }}
+        INPUT_REPO-TOKEN: ${{ inputs.repo-token }}
+        INPUT_ACCESS-TOKEN: ${{ inputs.access-token }}
+        INPUT_PROJECT-KEY: ${{ inputs.project-key }}
+        INPUT_ENVIRONMENT-KEY: ${{ inputs.environment-key }}
+        INPUT_PLACEHOLDER-COMMENT: ${{ inputs.placeholder-comment }}
+        INPUT_INCLUDE-ARCHIVED-FLAGS: ${{ inputs.include-archived-flags }}
+        INPUT_MAX-FLAGS: ${{ inputs.max-flags }}
+        INPUT_BASE-URI: ${{ inputs.base-uri }}
+        INPUT_CHECK-EXTINCTIONS: ${{ inputs.check-extinctions }}
+        INPUT_CREATE-FLAG-LINKS: ${{ inputs.create-flag-links }}
+        INPUT_SKIP-COMMENT: ${{ inputs.skip-comment }}
+        GITHUB_TOKEN: ${{ inputs.repo-token }}
+        LD_PROJ_KEY: ${{ inputs.project-key }}
+        LD_ACCESS_TOKEN: ${{ inputs.access-token }}
+        LD_BASE_URI: ${{ inputs.base-uri }}
+        LD_ENV_KEY: ${{ inputs.environment-key }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${DOCKER_IMAGE:-}" ]]; then
+          echo "::error::dockerImage input must not be empty"
+          exit 1
+        fi
+        if [[ -z "${GITHUB_WORKSPACE:-}" || ! -d "${GITHUB_WORKSPACE}" ]]; then
+          echo "::error::GITHUB_WORKSPACE is missing or not a directory; ensure actions/checkout ran before this step"
+          exit 1
+        fi
+        if [[ -z "${GITHUB_EVENT_PATH:-}" || ! -f "${GITHUB_EVENT_PATH}" ]]; then
+          echo "::error::GITHUB_EVENT_PATH is missing or not a readable file"
+          exit 1
+        fi
+        if [[ -z "${GITHUB_OUTPUT:-}" ]]; then
+          echo "::error::GITHUB_OUTPUT is missing; cannot set Action outputs"
+          exit 1
+        fi
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "::error::docker CLI not found on the runner; this Action entry point requires Docker"
+          exit 1
+        fi
+
+        # Ensure the output file exists so the container can append to it.
+        touch "${GITHUB_OUTPUT}"
+
+        proxy_env=()
+        for v in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+          if [[ -n "${!v:-}" ]]; then
+            proxy_env+=(-e "$v")
+          fi
+        done
+
+        docker run --rm \
+          -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+          -w "${GITHUB_WORKSPACE}" \
+          -v "${GITHUB_EVENT_PATH}:${GITHUB_EVENT_PATH}:ro" \
+          -v "${GITHUB_OUTPUT}:${GITHUB_OUTPUT}" \
+          -e GITHUB_WORKSPACE \
+          -e GITHUB_EVENT_PATH \
+          -e GITHUB_OUTPUT \
+          -e GITHUB_REPOSITORY \
+          -e GITHUB_REPOSITORY_OWNER \
+          -e GITHUB_REF \
+          -e GITHUB_SERVER_URL \
+          -e GITHUB_ACTIONS=true \
+          -e GITHUB_TOKEN \
+          -e "INPUT_REPO-TOKEN" \
+          -e "INPUT_ACCESS-TOKEN" \
+          -e "INPUT_PROJECT-KEY" \
+          -e "INPUT_ENVIRONMENT-KEY" \
+          -e "INPUT_PLACEHOLDER-COMMENT" \
+          -e "INPUT_INCLUDE-ARCHIVED-FLAGS" \
+          -e "INPUT_MAX-FLAGS" \
+          -e "INPUT_BASE-URI" \
+          -e "INPUT_CHECK-EXTINCTIONS" \
+          -e "INPUT_CREATE-FLAG-LINKS" \
+          -e "INPUT_SKIP-COMMENT" \
+          -e LD_PROJ_KEY \
+          -e LD_ACCESS_TOKEN \
+          -e LD_BASE_URI \
+          -e LD_ENV_KEY \
+          "${proxy_env[@]}" \
+          "${DOCKER_IMAGE}"

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -187,5 +187,8 @@ runs:
           -e LD_ACCESS_TOKEN \
           -e LD_BASE_URI \
           -e LD_ENV_KEY \
+          -e GIT_CONFIG_COUNT=1 \
+          -e GIT_CONFIG_KEY_0=safe.directory \
+          -e GIT_CONFIG_VALUE_0="${GITHUB_WORKSPACE}" \
           "${proxy_env[@]}" \
           "${DOCKER_IMAGE}"


### PR DESCRIPTION
## Summary
- Add opt-in `launchdarkly/find-code-references-in-pull-request/docker` composite Action with a `dockerImage` input so workflows can pull a prebuilt runtime image (or registry mirror) instead of relying on GitHub’s Docker Action build path.
- Multi-stage `Dockerfile` ships binary + `git` only; new `publish-image.yml` pushes `launchdarkly/find-code-references-in-pull-request:X.Y.Z` to Docker Hub on tag/`workflow_dispatch`.
- Root Action contract (`action.yml`) is unchanged for existing `@v2` consumers. Docs/CHANGELOG updated; default `dockerImage` pins `2.3.0` for the follow-up release.

## Test plan
- [x] CI `go-test` / existing `e2e-tests` still green
- [x] New `e2e-docker-entrypoint`: root vs local `/docker` output parity, GHCR mirror pull, fail-loud empty `dockerImage` + missing `GITHUB_WORKSPACE`
- [ ] Local/CI image build includes `git` (`docker run … git --version`)
- [ ] Manual smoke in fixture repo: checkout this branch, build image, run root + `/docker` (+ optional GHCR mirror) and compare `any-changed` / flag list outputs
- [ ] After release: Hub tag `2.3.0` exists before documenting default Hub pulls


Made with [Cursor](https://cursor.com)