### PR TITLE
prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## 2.3.0
+
+### Added
+
 - optional GitHub Action entry point `launchdarkly/find-code-references-in-pull-request/docker` with a `dockerImage` input so workflows can pull a prebuilt runtime image from a private registry or Docker Hub proxy. The root Action is unchanged.
 - multi-stage `Dockerfile` and Docker Hub publish workflow for `launchdarkly/find-code-references-in-pull-request` runtime images
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const Version = "2.2.0"
+const Version = "2.3.0"


### PR DESCRIPTION
## Summary
- Bump `internal/version/version.go` to **2.3.0**
- Move changelog notes from `[Unreleased]` into `## 2.3.0` (opt-in `/docker` entry point + runtime image publish workflow)

`docker/action.yml` / README already pin `2.3.0` as the default image tag.

## After merge (
1. Create GitHub Release + tag `v2.3.0` with Marketplace publish checked
2. Move floating major tag: `git tag -fa v2 -m "Update major version to v2.3.0" v2.3.0 && git push origin v2 --force`
3. Optional (new): publish Hub runtime image via `publish-image.yml` once `DOCKERHUB_*` is available — not required for Marketplace/`@v2` root Action

## Test plan
- [ ] CI green
- [ ] After release: smoke root `@v2.3.0` and optionally `/docker@v2.3.0` in fixture repo


Made with [Cursor](https://cursor.com)