### PR TITLE
fix: fail fast when AWS_ROLE_ARN is unset for image publish

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -58,6 +58,14 @@ jobs:
         with:
           ref: ${{ steps.version.outputs.git_tag }}
 
+      - name: Require AWS_ROLE_ARN
+        run: |
+          set -euo pipefail
+          if [[ -z "${{ vars.AWS_ROLE_ARN }}" ]]; then
+            echo "::error::Missing Actions variable AWS_ROLE_ARN. Set it on this repository to the same release role used by ld-find-code-refs (OIDC must trust launchdarkly/find-code-references-in-pull-request)."
+            exit 1
+          fi
+
       - name: Get Docker Hub credentials
         uses: launchdarkly/gh-actions/actions/release-secrets@release-secrets-v1.2.0
         with:


### PR DESCRIPTION
## Summary
- Publish run https://github.com/launchdarkly/find-code-references-in-pull-request/actions/runs/31824972959 failed because `vars.AWS_ROLE_ARN` is unset on this repo, so `release-secrets` could not assume a role (`Credentials could not be loaded`).
- Add an explicit preflight error pointing at the required Actions variable / OIDC trust (same pattern as `ld-find-code-refs`).

## After this
1. Copy/set repo Actions variable `AWS_ROLE_ARN` from `ld-find-code-refs` (or equivalent release role).
2. Ensure the role trust policy allows `repo:launchdarkly/find-code-references-in-pull-request:*` (OIDC).
3. Re-run **Publish Docker image** with `version: 2.3.0`.


Made with [Cursor](https://cursor.com)