### PR TITLE
fix(ci): de-privilege fork unit tests to close PWN-request exposure (Wiz f0dca03e)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 # Run test file with command:
 #   act pull_request -e testdata/act/pull-request.json
 #
-# Fork PRs only run jobs that do not need repository secrets here. See test-fork-pr.yml
-# for the label-gated workflow that runs go-test and e2e tests on forks.
+# Fork PRs only run jobs that do not need repository secrets here. go-test and
+# generate-docs run for forks under this unprivileged trigger; the steps inside them that
+# need secrets stay gated to same-repo PRs. See test-fork-pr.yml for the label-gated
+# workflow that runs the e2e tests on forks.
 
 name: Test and Generate Docs
 
@@ -10,11 +12,13 @@ on: pull_request
 
 jobs:
   go-test:
-    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          # This job runs fork-authored code. Don't leave a usable token in .git/config.
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
@@ -235,6 +239,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          # This job runs fork-authored code. Don't leave a usable token in .git/config.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548

--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -1,4 +1,4 @@
-# Runs go-test and e2e tests on fork PRs after a maintainer adds the "safe-to-test" label.
+# Runs the e2e tests on fork PRs after a maintainer adds the "safe-to-test" label.
 # This uses pull_request_target so repository secrets are available (fork PRs cannot
 # access secrets via the regular pull_request trigger). The label gate ensures untrusted
 # code is reviewed before it runs with access to secrets.
@@ -6,6 +6,11 @@
 # Security: Only the "labeled" event triggers this workflow. New pushes to the fork do NOT
 # re-trigger tests — see remove-safe-to-test-label.yml which strips the label on new commits,
 # forcing a maintainer to re-review and re-label.
+#
+# Scope: only the e2e job lives here. It is irreducibly privileged — it exists to run the
+# fork's own action code against the LaunchDarkly API, so it needs both the untrusted
+# checkout and LD_ACCESS_TOKEN_WRITER. Unit tests need no secrets and therefore run under
+# the unprivileged `pull_request` trigger in main.yml instead of here.
 name: "Test (Fork PRs)"
 
 on:
@@ -16,74 +21,6 @@ permissions:
   contents: read
 
 jobs:
-  go-test:
-    if: >-
-      github.event.label.name == 'safe-to-test'
-      && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
-        with:
-          node-version: '18.x'
-
-      - name: Install datadog-ci
-        run: npm install -g @datadog/datadog-ci
-
-      - name: Set up Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548
-        with:
-          python-version: '3.x'
-
-      - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
-        with:
-          go-version-file: go.mod
-          cache: false
-
-      - name: Install pre-commit
-        run: |
-          python -m pip install --upgrade pip
-          pip install pre-commit
-
-      - name: Run pre-commit hooks
-        run: pre-commit run --all-files
-
-      - name: Install dependencies
-        run: go mod tidy
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
-
-      - name: Run tests with gotestsum
-        run: |
-          mkdir -p ${{ github.workspace }}/artifacts
-          mkdir -p ${{ github.workspace }}/reports
-
-          GONFALON_MODE=test \
-          gotestsum --packages="./..." \
-            --junitfile ${{ github.workspace }}/reports/go-test_go_tests.xml \
-            --jsonfile ${{ github.workspace }}/artifacts/go-test_go_tests.json \
-            --rerun-fails=2 \
-            --rerun-fails-max-failures=10 \
-            --rerun-fails-report ${{ github.workspace }}/artifacts/rerun_tests_go_tests.txt \
-            -- -tags=launchdarkly_easyjson -p=1
-
-      - name: Publish JUnit Tests
-        uses: ./.github/actions/publish-junit
-        env:
-          DD_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        with:
-          files: ${{ github.workspace }}/reports/go-test_go_tests.xml
-          name: find-code-references-in-pull-request
-          datadog: 'true'
-          github: 'true'
-
   e2e-tests:
     if: >-
       github.event.label.name == 'safe-to-test'
@@ -97,6 +34,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Untrusted fork code runs in this job. Keep the workflow token out of
+          # .git/config so poisoned code cannot reuse it.
+          persist-credentials: false
       - name: Find LaunchDarkly feature flags in diff
         uses: ./ # Uses an action in the root directory
         id: find-flags
@@ -140,7 +80,6 @@ jobs:
   check-success:
     name: "Check Success (Fork)"
     needs:
-      - go-test
       - e2e-tests
     if: always()
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

[Wiz issue `f0dca03e`](https://app.wiz.io/issues#~(issue~'f0dca03e-007b-49a4-a459-05b4aad4f094) — **CRITICAL**, "Publicly exposed CI workflow with access to secrets vulnerable to PWN request." Opened 2026-07-31, reopened 2026-08-09.

Heads up for anyone reading that issue cold: the issue's affected entity says `.github/workflows/main.yml`, but Wiz's own IaC scanner names the real file as **`.github/workflows/test-fork-pr.yml`**. `main.yml` uses `pull_request`, which never hands secrets to fork code. Don't chase `main.yml`.

Wiz has four line-level findings, all in `test-fork-pr.yml`:

| Job | Finding | Cleared here? |
|---|---|---|
| `go-test` | untrusted checkout `ref: head.sha` in a privileged context | ✅ |
| `go-test` | local action `uses: ./.github/actions/publish-junit` after untrusted checkout | ✅ |
| `e2e-tests` | untrusted checkout `ref: head.sha` in a privileged context | ❌ by design |
| `e2e-tests` | local action `uses: ./` after untrusted checkout | ❌ by design |

The finding is a true positive in mechanism. Under `pull_request_target`, fork-authored code executes before the secret-bearing step, so it can poison `$GITHUB_ENV`/`PATH`/the local action definition and capture the secret. The `safe-to-test` label gate (#238) is a real control, but it is a human-review control — it depends on a maintainer catching a hostile `action.yml`, `.pre-commit-config.yaml`, or `Dockerfile` in the diff.

## What changed

**The two `go-test` findings are avoidable, and this PR removes them.** Unit tests need no repository secrets — only the "Publish JUnit Tests" step does, and that step *already* carries its own same-repo `if:` guard. So fork unit tests never needed `pull_request_target`:

- **`main.yml`** — dropped the job-level same-repo gate on `go-test`, so fork PRs get unit test coverage under the unprivileged `pull_request` trigger. The Datadog publish step stays gated, so `DATADOG_API_KEY` is now never present in any job that runs fork code.
- **`test-fork-pr.yml`** — deleted the redundant privileged `go-test` job; updated `check-success`'s `needs:`.
- **All checkouts of fork-authored code** — added `persist-credentials: false`, so poisoned code can't reuse the workflow token out of `.git/config`.

Net: 4 findings → 2, and `DATADOG_API_KEY` leaves the privileged blast radius entirely.

## What this PR does *not* fix, and why

The `e2e-tests` job is **irreducibly privileged**. Its entire purpose is to run the fork's own action code against the real LaunchDarkly API, so it needs both the untrusted checkout and `LD_ACCESS_TOKEN_WRITER` in the same job. Wiz's suggested Strategies A/B/C (check out base instead of head; isolate fork code to a subdirectory; hand off artifacts via `workflow_run`) all break the test's purpose — there is nothing to test if you don't run the fork's code. So the two `e2e-tests` findings survive this PR by design, still mitigated by the label gate.

**So merging this PR will not close the Wiz issue,** and that's expected. I checked how this rule has been closed before: tenant-wide it has been resolved exactly once, as `ISSUE_FIXED`, and the resolution evidence is *deletion of the `IAC_FINDING` resource* — i.e. the pattern was removed from the YAML. It has never been closed via a compensating control. Wiz's two remaining checks are IaC pattern matchers on `pull_request_target` + `ref: head.sha` + `uses: ./`, so any runtime control leaves them matching. Closing the residual will need an explicit risk acceptance in Wiz, not another workflow edit. ProdSec (me) will handle that side.

**Optional hardening worth considering on its own merits** (not a route to closing the Wiz findings): move `LD_ACCESS_TOKEN_WRITER` into a GitHub **Environment with required reviewers** and add `environment: fork-e2e` to `e2e-tests`. Per [GitHub's docs](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments), "a job that references an environment must follow any protection rules for the environment **before running** or accessing the environment's secrets" — the job is held in `Waiting` before *any* step, so the untrusted checkout never happens without a per-run human approval. That's genuinely stronger than the label gate: it can't go stale and can't be raced by a push. I didn't wire it here because an Environment with no protection rules is a silent no-op that *looks* like a control, and picking the reviewer set is your call. Happy to open that PR if you want it.

Also worth confirming: `LD_ACCESS_TOKEN_WRITER` should be scoped to the `developer-toolbar-sandbox` project only. If it already is, the residual blast radius is one sandbox project and the remaining risk is low.

## On secret rotation

Wiz's remediation plan says rotate both secrets. I checked whether the exposure was ever actually exercised, since exploitation requires a maintainer to have labeled a *hostile* fork PR `safe-to-test`:

- Only two fork PRs have ever carried the label: #234 and #235, both from the `Fieldguide` fork, both authored by @jazanne.
- All six `test-fork-pr.yml` runs to date were on those two PRs, labeled by @cspath1 and @tknopp-ld.

So no untrusted third-party code has ever run in the privileged context. **Rotation is precautionary, not incident-driven** — your call whether it's worth the churn. Nothing here indicates compromise.

## Review notes / risk

- **`go-test` is a required status check.** It's still produced for fork PRs — by `main.yml` now instead of `test-fork-pr.yml` — and it no longer needs a maintainer label to report, which is a small improvement to fork contributor experience. `Check Success (Fork)` is not a required check, so the `needs:` change is safe.
- **More CI on unreviewed forks?** No. The repo already has Actions → `approval_policy: all_external_contributors`, so an external fork PR can't run *any* workflow until a maintainer approves the run.
- **Lost capability:** fork PRs no longer publish JUnit results to Datadog. They already didn't before this PR (the step was gated), so this is unchanged in practice.
- **One thing I could not exercise, please sanity-check in review:** `test-fork-pr.yml` only fires on `pull_request_target` + `labeled` + fork head, so *this* PR (same-repo) never ran it — the green `e2e-tests` check above is `main.yml`'s job. That means the `persist-credentials: false` I added directly above `uses: ./` is unexercised. The `go-test`/`generate-docs` runs here do prove `persist-credentials: false` survives `go mod tidy` and `pre-commit run --all-files`, but not that step. You'd know better than I do whether `ld-find-code-refs` needs a persisted git credential; if it does, drop that one line. Alternatively label a throwaway fork PR `safe-to-test` to confirm.
- **Verified with `actionlint`:** no new findings. The SC2209 count actually drops 2 → 1 because the duplicated test block is gone. Remaining shellcheck nits are pre-existing and on untouched lines.

via LD Research 🤖
