### PR TITLE
fix: skip comment logic was backwards

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,7 +96,7 @@ func main() {
 			Body: &postedComments,
 		}
 
-		if !config.SkipComment {
+		if config.SkipComment {
 			gha.Log("Skipping comment creation as skip-comment is set to true")
 		} else {
 			err = postGithubComment(ctx, flagsRef, config, existingComment, *event.PullRequest.Number, comment)


### PR DESCRIPTION
I introduced the wrong logic for skip comment in https://github.com/launchdarkly/find-code-references-in-pull-request/pull/234

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Corrects a logic inversion in **`main.go`** for the `skip-comment` config (`INPUT_SKIP-COMMENT`).
> 
> When **`config.SkipComment`** is **true**, the action now logs that comment creation is skipped and does **not** call **`postGithubComment`**. When it is **false**, it posts or updates the comment as before. The previous **`!config.SkipComment`** branch had the opposite behavior relative to the log message and intended option semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f927d77e616824b6b67f42d88e4ca03f8ab76ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->